### PR TITLE
Remove 'trusty' from Travis build because 'dist: trusty is no longer …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env: _R_CHECK_FORCE_SUGGESTS_=FALSE
 
 matrix:
   include:
-    - dist: trusty
     - dist: xenial
     - os: osx
       brew_packages: protobuf


### PR DESCRIPTION
…supported for language: r'