### PR TITLE
read_mvt_sf() can now read single point lines

### DIFF
--- a/R/mvt.R
+++ b/R/mvt.R
@@ -94,13 +94,13 @@ mvt_sf_point <- function(mat){
   if(nrow(mat) == 1){
     sf::st_point(mat[1:2])
   } else {
-    sf::st_multipoint(mat[,1:2])
+    sf::st_multipoint(mat[,1:2, drop = FALSE])
   }
 }
 
 mvt_sf_linestring <- function(mat){
   if(all_equal(mat[,3])){
-    sf::st_linestring(mat[,1:2])
+    sf::st_linestring(mat[,1:2, drop = FALSE])
   } else {
     sf::st_multilinestring(split_matrix_groups(mat))
   }


### PR DESCRIPTION
Fixed bug that prevented read_mvt_sf() from reading lines that consist of a single point.
Matrix dimensions are now preserved in this edge case.

Fixes #22