### PR TITLE
Use protobuf from Rtools if found

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,6 +22,7 @@ jobs:
           - {os: macos-14,        r: 'release'}
           - {os: windows-latest,  r: '4.1'}
           - {os: windows-latest,  r: '4.2'}
+          - {os: windows-latest,  r: '4.3'}
           - {os: windows-latest,  r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Pure C++ implementations for reading and writing several common dat
     hence the entire serialization is optimized at compile time. The 'RProtoBuf' 
     package on the other hand uses the protobuf runtime library to provide a general-
     purpose toolkit for reading and writing arbitrary protocol-buffer data in R.
-Version: 2.3.1
+Version: 2.4.0
 License: MIT + file LICENSE
 URL: https://github.com/jeroen/protolite 
     https://jeroen.r-universe.dev/protolite

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+2.4.0
+  - Windows: use protobuf from Rtools if available
+
 2.3.0
   - Windows: update to protobuf 21.12
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -2,6 +2,7 @@ PKG_CONFIG_NAME = protobuf
 PKG_CONFIG ?= $(BINPREF)pkg-config
 PKG_LIBS := $(shell $(PKG_CONFIG) --libs $(PKG_CONFIG_NAME))
 PROTOC_VERSION := $(shell protoc --version)
+PROTOCS = geobuf.pb.h mvt.pb.h rexp.pb.h
 
 ifneq ($(PKG_LIBS),)
 ifneq ($(PROTOC_VERSION),)
@@ -19,14 +20,14 @@ endif
 
 all: $(SHLIB)
 
-$(OBJECTS): $(RWINLIB) protocs
+$(OBJECTS): $(RWINLIB) $(PROTOCS)
 
 $(RWINLIB):
 	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R"
 
-protocs:
+$(PROTOCS):
 	"$(PROTOC_DIR)protoc" *.proto --cpp_out=.
 
 clean:
-	rm -f $(OBJECTS) $(SHLIB) *.pb.cc *.pb.h
+	rm -f $(OBJECTS) $(SHLIB) $(PROTOCS) *.pb.cc
 	(cd ..; sh cleanup)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,15 +1,31 @@
+PKG_CONFIG_NAME = protobuf
+PKG_CONFIG ?= $(BINPREF)pkg-config
+PKG_LIBS := $(shell $(PKG_CONFIG) --libs $(PKG_CONFIG_NAME))
+PROTOC_VERSION := $(shell protoc --version)
+
+ifneq ($(PKG_LIBS),)
+ifneq ($(PROTOC_VERSION),)
+$(info using $(PKG_CONFIG_NAME) and $(PROTOC_VERSION) from Rtools)
+PKG_CPPFLAGS := $(shell $(PKG_CONFIG) --cflags $(PKG_CONFIG_NAME)) -DUSENEWAPI
+endif
+endif
+
+ifeq ($(PKG_CPPFLAGS),)
 RWINLIB = ../windows/protobuf
-PKG_CPPFLAGS= -I$(RWINLIB)/include -DUSENEWAPI
-PKG_LIBS= -L$(RWINLIB)/lib${subst gcc,,${COMPILED_BY}}${R_ARCH} \
-	-L$(RWINLIB)/lib \
-	-lprotobuf
-BINDIR=$(RWINLIB)/bin$(subst 64,,$(WIN))
+PKG_CPPFLAGS = -I$(RWINLIB)/include -DUSENEWAPI
+PKG_LIBS = -L$(RWINLIB)/lib${subst gcc,,${COMPILED_BY}}${R_ARCH} -L$(RWINLIB)/lib -lprotobuf
+PROTOC_DIR = $(RWINLIB)/bin$(subst 64,,$(WIN))/
+endif
 
-all: clean winlibs
+all: $(SHLIB)
 
-winlibs:
+$(OBJECTS): $(RWINLIB) protocs
+
+$(RWINLIB):
 	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R"
-	"${BINDIR}/protoc" *.proto --cpp_out=.
+
+protocs:
+	"$(PROTOC_DIR)protoc" *.proto --cpp_out=.
 
 clean:
 	rm -f $(OBJECTS) $(SHLIB) *.pb.cc *.pb.h

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -6,7 +6,7 @@ PROTOC_VERSION := $(shell protoc --version)
 ifneq ($(PKG_LIBS),)
 ifneq ($(PROTOC_VERSION),)
 $(info using $(PKG_CONFIG_NAME) and $(PROTOC_VERSION) from Rtools)
-PKG_CPPFLAGS := $(shell $(PKG_CONFIG) --cflags $(PKG_CONFIG_NAME)) -DUSENEWAPI
+PKG_CPPFLAGS := $(subst -Wnon-virtual-dtor,,$(shell $(PKG_CONFIG) --cflags $(PKG_CONFIG_NAME))) -DUSENEWAPI
 endif
 endif
 


### PR DESCRIPTION
It works but creates some new warnings. Also protobuf in rtools seems much heavier because of all the absl libs.
 - R-4.3: https://win-builder.r-project.org/F3rbgaNdD2Pp/00check.log (WARNING)
 - R-4.4: https://win-builder.r-project.org/2ZZV2B3h7eRn/00check.log (NOTE)